### PR TITLE
Harden live upload and editor recovery

### DIFF
--- a/video-publisher/SKILL.md
+++ b/video-publisher/SKILL.md
@@ -178,6 +178,8 @@ The production orchestrator then passed a real four-platform regression with upl
 
 The onboarded `all_videos_original` policy also passed real mutation without `--confirm-original-rights`. After a targeted Xiaohongshu cover receipt reset, the maintained runner re-uploaded the 3:4 asset on its first attempt; three immediate full four-platform reruns then remained `READY` with no upload or UI mutation work.
 
+A second cold-start regression used a different 308 MB source video and four fresh task spaces. Bilibili quarantined a real foreign draft before upload. Douyin recovered from a visible upload failure with bounded reinjection, then rebuilt a corrupted rich description into the exact body plus five topic entities. Bilibili closed a framework-swallowed cover dialog through its exact scoped completion control. Both platforms wrote fingerprint-bound cover checkpoints. After the main-state receipts were deliberately removed, the next full run restored them from those checkpoints and all four platforms returned `READY` without upload or mutation. Three additional consecutive full reruns were also no-op `READY` passes. No final publish control was clicked.
+
 A passing platform-specific diagnostic still does not replace this system-level regression when scheduler, persistence, or shared-browser behavior changes.
 
 Real creator-page evidence is the acceptance gate for adapter changes. Unit tests validate orchestration and parsing, not live selectors.

--- a/video-publisher/references/intake-workflow.md
+++ b/video-publisher/references/intake-workflow.md
@@ -15,7 +15,7 @@ If the link points to an already-published creator platform post, treat it as a 
 
 Before any browser upload, verify the local file exists with `ls -lh` or `test -f`.
 
-Before selecting any `原创`, `自制`, or equivalent declaration, ask the user to confirm in the current run that the video qualifies. If not confirmed, stop before mutation; do not guess or reuse a prior run's answer.
+Before selecting any `原创`, `自制`, or equivalent declaration, require the onboarded `declarations.originalityPolicy` to be `all_videos_original`, or obtain current-video confirmation and pass the one-run `--confirm-original-rights` override. Never infer eligibility from the filename or content. Treat this declaration signal separately from final-publish authorization.
 
 If the exact path does not exist:
 

--- a/video-publisher/references/platform-bilibili.md
+++ b/video-publisher/references/platform-bilibili.md
@@ -63,6 +63,8 @@ Use the user-provided `4:3` asset only when enabled.
 
 Upload through the active `.bcc-upload-wrapper` image input. The cover editor’s final control can be a `div.button.submit`, not a native button. Wait until its exact label becomes `完成`, click it through the real input channel, and require the editor to close.
 
+On the currently tested editor, a correctly targeted real selector click may still be swallowed by the framework. First attempt the real click. If the same visible `封面制作` dialog and the same enabled `.button.submit` control remain after the settle window, the adapter may invoke that exact scoped control through the page framework once. Record `frameworkFallbackUsed`, then still require the dialog to close and the accepted main-page cover URL to appear. Never broaden this fallback to text search or to any final-publish control.
+
 Read the accepted main cover from `.cover .cover-content .cover-img`. Persist its `archive.biliimg.com` or `biliimg.com` URL as the receipt. The same content-addressed URL may remain when re-uploading the identical file, so proof requires the upload action, enabled completion control, closed editor, and accepted main-page URL together.
 
 ## Required Gates
@@ -80,4 +82,4 @@ visible enabled 立即投稿 button
 final publish not clicked
 ```
 
-The complete draft path passed real testing on 2026-07-14.
+The complete draft path passed real testing on 2026-07-14, including foreign-draft quarantine, the scoped cover-completion fallback, checkpoint recovery, and repeated no-op verification.

--- a/video-publisher/references/platform-douyin.md
+++ b/video-publisher/references/platform-douyin.md
@@ -10,17 +10,19 @@ Use the 1-5 topic entities supplied by `douyinTopics`, in order. Do not inject a
 
 If the upload page asks whether to continue the last unpublished video, discard that stale upload before starting the confirmed target. Use a real visible click; do not treat hidden dialog text as active.
 
-Clear the rich description editor with real focus, a programmatic selection, and real Backspace. Direct value replacement can leave duplicated framework state.
+Treat a visible `上传失败，重新上传` state as terminal evidence for the current upload attempt. Clear the file input, retry the same verified local asset once in the same run, and record the attempt count. Do not spend the whole processing timeout waiting after explicit failure. A second explicit failure is `PLATFORM_REJECTED_ASSET`; a progress state that simply stops advancing remains `UPLOAD_STALLED`.
+
+Clear the rich description editor with a real click inside the editor followed by real `Meta+A` and Backspace, then verify it is empty before rebuilding content. Direct value replacement or DOM-only selection can leave duplicated framework state.
 
 ## Topic Entities
 
 For each topic:
 
-1. Focus the description at the end.
+1. Resolve the last text node in the editor and real-click its endpoint; do not use a guessed top-right coordinate.
 2. Click the real `#添加话题` control.
 3. Insert the bare topic through CDP `Input.insertText`.
 4. Click the exact leaf suggestion row.
-5. Verify a committed topic entity before continuing.
+5. Press real ArrowRight to leave the committed entity, insert one separator space, and verify the entity before continuing.
 
 Accept the platform’s official activity entity form and exact selected `#话题` form. Reject plain hashtag residue and duplicates.
 
@@ -60,4 +62,4 @@ visible enabled 发布 button
 final publish not clicked
 ```
 
-This path passed a fresh real draft run on 2026-07-14.
+This path passed a fresh 308 MB real draft run on 2026-07-14, including recovery from an explicit upload failure, exact reconstruction of a previously corrupted rich description, and repeated no-op verification.

--- a/video-publisher/scripts/v2/platforms/bilibili.mjs
+++ b/video-publisher/scripts/v2/platforms/bilibili.mjs
@@ -94,20 +94,31 @@ async function uploadBilibiliCoverV2(){
   const exposed=await js(String.raw`(() => {const input=[...document.querySelectorAll('.bcc-upload-wrapper input[type=file],input[type=file]')].find(el=>/image|png|jpe?g/i.test(el.accept||''));if(!input)return {ok:false,reason:'bilibili cover image input missing'};input.id='vp2-bili-cover';return {ok:true,selector:'#vp2-bili-cover'}})()`);
   if(!exposed.ok)return exposed;
   try{await uploadFile(exposed.selector,bilibiliCoverPath)}catch(error){return {ok:false,reason:String(error?.message||error)}}
-  let confirmPoint=null;
-  for(let poll=0;poll<90&&!confirmPoint;poll+=1){
+  let confirmControl=null;
+  for(let poll=0;poll<90&&!confirmControl;poll+=1){
     await wait(.5);
-    confirmPoint=await js(String.raw`(() => {const c=v=>String(v||'').replace(/\s+/g,' ').trim();const active=[...document.querySelectorAll('.bcc-dialog,.bcc-modal,[role="dialog"]')].filter(el=>{const r=el.getBoundingClientRect(),s=getComputedStyle(el);return r.width>20&&r.height>20&&s.display!=='none'&&s.visibility!=='hidden'&&Number(s.opacity||1)>0});const candidates=active.flatMap(dialog=>[...dialog.querySelectorAll('.button.submit,button,[role="button"],div,span')]).filter(el=>{const r=el.getBoundingClientRect(),s=getComputedStyle(el);return /^(完成|确定|保存|使用|应用)$/.test(c(el.innerText||el.textContent||''))&&!el.disabled&&r.width>20&&r.height>15&&s.display!=='none'&&s.visibility!=='hidden'&&Number(s.opacity||1)>0}).map(el=>({el,r:el.getBoundingClientRect(),submit:/submit/.test(String(el.className||''))})).sort((a,b)=>Number(b.submit)-Number(a.submit)||(a.r.width*a.r.height-b.r.width*b.r.height));if(!candidates[0])return null;const r=candidates[0].r;return {x:r.left+r.width/2,y:r.top+r.height/2,text:c(candidates[0].el.innerText||candidates[0].el.textContent||'')}})()`);
+    confirmControl=await js(String.raw`(() => {const c=v=>String(v||'').replace(/\s+/g,' ').trim();const active=[...document.querySelectorAll('.bcc-dialog,.bcc-modal,[role="dialog"]')].filter(el=>{const r=el.getBoundingClientRect(),s=getComputedStyle(el);return r.width>20&&r.height>20&&s.display!=='none'&&s.visibility!=='hidden'&&Number(s.opacity||1)>0});const candidates=active.flatMap(dialog=>[...dialog.querySelectorAll('.button.submit,button,[role="button"],div,span')]).filter(el=>{const r=el.getBoundingClientRect(),s=getComputedStyle(el);return /^(完成|确定|保存|使用|应用)$/.test(c(el.innerText||el.textContent||''))&&!el.disabled&&el.getAttribute('aria-disabled')!=='true'&&r.width>20&&r.height>15&&s.display!=='none'&&s.visibility!=='hidden'&&Number(s.opacity||1)>0}).map(el=>({el,r:el.getBoundingClientRect(),submit:/submit/.test(String(el.className||''))})).sort((a,b)=>Number(b.submit)-Number(a.submit)||(a.r.width*a.r.height-b.r.width*b.r.height));if(!candidates[0])return null;const el=candidates[0].el;el.id='vp2-bili-cover-confirm';return {selector:'#vp2-bili-cover-confirm',text:c(el.innerText||el.textContent||''),className:String(el.className||'')}})()`);
   }
-  if(!confirmPoint)return {ok:false,reason:'bilibili cover confirm missing'};
-  await click([confirmPoint.x,confirmPoint.y],{label:'confirm bilibili cover'}).catch(()=>{});
+  if(!confirmControl)return {ok:false,reason:'bilibili cover confirm missing'};
+  try{await click(confirmControl.selector,{label:'confirm bilibili cover'})}catch(error){return {ok:false,reason:`bilibili cover confirm click failed: ${String(error?.message||error)}`,confirmControl}}
   let after=[];
   let dialogClosed=false;
-  for(let poll=0;poll<60;poll+=1){await wait(.5);const state=await inspectBilibili();after=state.gates.cover.evidence?.urls||[];dialogClosed=state.gates.noBlockingDialog.ok;if(dialogClosed&&after.some(url=>/archive\.biliimg|biliimg/.test(url)))break}
+  let frameworkFallbackUsed=false;
+  for(let poll=0;poll<60;poll+=1){
+    await wait(.5);
+    const state=await inspectBilibili();
+    after=state.gates.cover.evidence?.urls||[];
+    dialogClosed=state.gates.noBlockingDialog.ok;
+    if(dialogClosed&&after.some(url=>/archive\.biliimg|biliimg/.test(url)))break;
+    if(poll===10&&!dialogClosed){
+      const fallback=await js(String.raw`(() => {const c=v=>String(v||'').replace(/\s+/g,' ').trim();const dialog=[...document.querySelectorAll('.bcc-dialog,.bcc-modal,[role="dialog"]')].find(el=>{const r=el.getBoundingClientRect(),s=getComputedStyle(el);return r.width>20&&r.height>20&&s.display!=='none'&&s.visibility!=='hidden'&&/封面制作/.test(c(el.innerText||el.textContent||''))});const button=[...(dialog?.querySelectorAll('.button.submit')||[])].find(el=>c(el.innerText||el.textContent||'')==='完成'&&!el.disabled&&el.getAttribute('aria-disabled')!=='true');if(!button)return{ok:false};button.click();return{ok:true}})()`);
+      frameworkFallbackUsed=fallback.ok===true;
+    }
+  }
   const afterUrl=after.find(url=>!before.includes(url))||after.find(url=>/archive\.biliimg|biliimg/.test(url))||after[0];
-  if(!dialogClosed)return {ok:false,reason:'bilibili cover editor did not close after confirmation',before,after};
+  if(!dialogClosed)return {ok:false,reason:'bilibili cover editor did not close after confirmation',before,after,frameworkFallbackUsed};
   if(!afterUrl)return {ok:false,reason:'bilibili main cover did not expose CDN receipt',before,after};
-  return {ok:true,receipt:{assetPath:bilibiliCoverPath,ratio:'4:3',beforeUrls:before,afterUrl}};
+  return {ok:true,frameworkFallbackUsed,receipt:{assetPath:bilibiliCoverPath,ratio:'4:3',beforeUrls:before,afterUrl}};
 }
 
 async function mutateBilibili(){const before=await inspectBilibili();if(!before.gates.video.ok)return {...before,blocker:typedBlocker('STATE_AMBIGUOUS','B站没有可修复的已上传视频')};const actions={};if(!before.gates.title.ok)actions.title=await setNativeInputValue('input[placeholder*="稿件标题"]',bilibiliTitle);if(!before.gates.description.ok)actions.description=await setBilibiliDescriptionV2();if(actions.description&&!actions.description.ok)return {...(await inspectBilibili()),blocker:typedBlocker('ACTION_FAILED',actions.description.reason)};if(!before.gates.original.ok)actions.declaration=await ensureBilibiliDeclarationV2();if(actions.declaration&&!actions.declaration.ok)return {...(await inspectBilibili()),blocker:typedBlocker('ACTION_FAILED','B站创作声明没有持久化',{evidence:actions.declaration})};if(!before.gates.tags.ok){actions.tags=await rebuildBilibiliTagsV2();if(!actions.tags.ok)return {...(await inspectBilibili()),blocker:typedBlocker('PLATFORM_REJECTED_METADATA',actions.tags.reason,{retryable:true,evidence:actions.tags})}}const receipts={};if(bilibiliCustomCover){actions.cover=await uploadBilibiliCoverV2();if(!actions.cover.ok)return {...(await inspectBilibili()),blocker:typedBlocker('PLATFORM_REJECTED_ASSET',actions.cover.reason,{retryable:true,evidence:actions.cover})};receipts.cover=actions.cover.receipt;expectedReceipts.cover=receipts.cover}actions.receiptCheckpoint=checkpointReceipts(receipts);const after=await inspectBilibili();return {...after,actions,receipts}}

--- a/video-publisher/scripts/v2/platforms/douyin.mjs
+++ b/video-publisher/scripts/v2/platforms/douyin.mjs
@@ -103,12 +103,39 @@ async function uploadDouyin() {
     if(!point)return {...before,blocker:typedBlocker('SELECTOR_DRIFT','douyin discard button missing')};
     await click([point.x,point.y],{label:'discard stale douyin upload'}).catch(()=>{});await wait(1.5);
   }
-  const exposed=await js(String.raw`(() => { const input=[...document.querySelectorAll('input[type=file]')].find(el=>/video|\.mp4|\.mov|\.mkv|\.flv/i.test(el.accept||'')); if(!input)return {ok:false,reason:'douyin video input missing'}; input.id='vp2-douyin-video'; return {ok:true,selector:'#vp2-douyin-video'} })()`);
-  if(!exposed.ok)return {...before,blocker:typedBlocker('SELECTOR_DRIFT',exposed.reason)};
-  try{await uploadFile(exposed.selector,videoPath);}catch(error){return {...before,blocker:typedBlocker('UPLOAD_NOT_STARTED',String(error?.message||error),{retryable:true})};}
-  let stableSince=0;
-  for(let i=0;i<180;i+=1){const current=await inspectDouyin();if(current.gates.video.ok){if(!stableSince)stableSince=Date.now();if(Date.now()-stableSince>=10000)return current;}else stableSince=0;await wait(5);}
-  const after=await inspectDouyin();return {...after,blocker:typedBlocker('UPLOAD_STALLED','抖音视频没有在等待窗口内稳定完成',{retryable:true,evidence:after.gates.video.evidence})};
+  const attempts=[];
+  for(let attempt=1;attempt<=2;attempt+=1){
+    const exposed=await js(String.raw`(() => { const input=[...document.querySelectorAll('input[type=file]')].find(el=>/video|\.mp4|\.mov|\.mkv|\.flv/i.test(el.accept||'')); if(!input)return {ok:false,reason:'douyin video input missing'}; input.value=''; input.id='vp2-douyin-video'; return {ok:true,selector:'#vp2-douyin-video'} })()`);
+    if(!exposed.ok)return {...before,blocker:typedBlocker('SELECTOR_DRIFT',exposed.reason)};
+    try{await uploadFile(exposed.selector,videoPath);}catch(error){return {...before,blocker:typedBlocker('UPLOAD_NOT_STARTED',String(error?.message||error),{retryable:true,evidence:{attempt}})};}
+    let stableSince=0;
+    let activityObserved=false;
+    let current=before;
+    for(let i=0;i<180;i+=1){
+      await wait(5);
+      current=await inspectDouyin();
+      const video=current.gates.video.evidence||{};
+      if(video.uploading||video.failed!==true)activityObserved=true;
+      if(current.gates.video.ok){
+        if(!stableSince)stableSince=Date.now();
+        if(Date.now()-stableSince>=10000)return {...current,actions:{uploadAttempts:attempts.concat({attempt,result:'ready'})}};
+      }else stableSince=0;
+      if(video.failed===true&&!video.uploading&&(activityObserved||i>=5)){
+        attempts.push({attempt,result:'explicit_failure',evidence:video});
+        break;
+      }
+    }
+    const after=await inspectDouyin();
+    if(after.gates.video.ok)return {...after,actions:{uploadAttempts:attempts.concat({attempt,result:'ready'})}};
+    const video=after.gates.video.evidence||{};
+    if(video.failed===true&&attempt<2){await wait(2);before=after;continue;}
+    const blocker=video.failed===true
+      ? typedBlocker('PLATFORM_REJECTED_ASSET','抖音明确显示视频上传失败，已完成一次有界重试',{retryable:true,evidence:{attempts,video}})
+      : typedBlocker('UPLOAD_STALLED','抖音视频没有在等待窗口内稳定完成',{retryable:true,evidence:{attempts,video}});
+    return {...after,actions:{uploadAttempts:attempts},blocker};
+  }
+  const after=await inspectDouyin();
+  return {...after,blocker:typedBlocker('UPLOAD_STALLED','抖音视频重试后仍未稳定完成',{retryable:true,evidence:after.gates.video.evidence})};
 }
 
 async function setDouyinTitle() {
@@ -121,31 +148,48 @@ async function setDouyinTitle() {
   return after===douyinTitle?{ok:true,before,value:after}:{ok:false,reason:'douyin title input did not persist exact value',expected:douyinTitle,actual:after};
 }
 
-async function clearAndFillDouyinBody() {
-  const locate=()=>js(String.raw`(() => {
+async function locateDouyinEditor() {
+  return await js(String.raw`(() => {
     const compact=v=>String(v||'').replace(/\s+/g,' ').trim();const visible=el=>{const r=el.getBoundingClientRect(),s=getComputedStyle(el);return r.width>180&&r.height>50&&s.display!=='none'&&s.visibility!=='hidden'}
     const rows=[...document.querySelectorAll('[contenteditable="true"],[contenteditable=""]')].map(el=>{const r=el.getBoundingClientRect();let p=el.parentElement,context='';for(let i=0;p&&i<5;i+=1){context+=' '+compact(p.innerText||p.textContent||'');p=p.parentElement}return {el,r,context,cls:String(el.className||'')}}).filter(item=>visible(item.el)&&!item.el.closest('[role="dialog"],[class*="modal"],[class*="dialog"]')).sort((a,b)=>Number(/作品描述|#添加话题|@好友/.test(b.context))-Number(/作品描述|#添加话题|@好友/.test(a.context))||Number(/editor|zone|ace/.test(b.cls))-Number(/editor|zone|ace/.test(a.cls))||b.r.width*b.r.height-a.r.width*a.r.height)
-    const item=rows[0];if(!item)return {ok:false,reason:'douyin description editor missing'};item.el.scrollIntoView({block:'center',inline:'center'});return {ok:true,text:item.el.innerText||item.el.textContent||'',className:item.cls}
+    const item=rows[0];if(!item)return {ok:false,reason:'douyin description editor missing'};item.el.id='vp2-douyin-editor';item.el.scrollIntoView({block:'center',inline:'center'});return {ok:true,selector:'#vp2-douyin-editor',text:item.el.innerText||item.el.textContent||'',className:item.cls,point:{x:item.r.left+Math.min(24,item.r.width/4),y:item.r.top+Math.min(24,item.r.height/3)}}
   })()`);
-  const focus=(collapseEnd)=>js(String.raw`((collapseEnd) => {
-    const compact=v=>String(v||'').replace(/\s+/g,' ').trim();const visible=el=>{const r=el.getBoundingClientRect(),s=getComputedStyle(el);return r.width>180&&r.height>50&&s.display!=='none'&&s.visibility!=='hidden'}
-    const rows=[...document.querySelectorAll('[contenteditable="true"],[contenteditable=""]')].map(el=>{const r=el.getBoundingClientRect();let p=el.parentElement,context='';for(let i=0;p&&i<5;i+=1){context+=' '+compact(p.innerText||p.textContent||'');p=p.parentElement}return {el,r,context,cls:String(el.className||'')}}).filter(item=>visible(item.el)&&!item.el.closest('[role="dialog"],[class*="modal"],[class*="dialog"]')).sort((a,b)=>Number(/作品描述|#添加话题|@好友/.test(b.context))-Number(/作品描述|#添加话题|@好友/.test(a.context))||Number(/editor|zone|ace/.test(b.cls))-Number(/editor|zone|ace/.test(a.cls))||b.r.width*b.r.height-a.r.width*a.r.height)
-    const el=rows[0]?.el;if(!el)return {ok:false,reason:'douyin description editor missing'};el.focus();const selection=getSelection(),range=document.createRange();range.selectNodeContents(el);if(collapseEnd)range.collapse(false);selection.removeAllRanges();selection.addRange(range);return {ok:document.activeElement===el,selected:String(selection),text:el.innerText||el.textContent||''}
-  })(${JSON.stringify(collapseEnd)})`);
-  let located=await locate();if(!located.ok)return located;
+}
+
+async function focusDouyinEditorEnd() {
+  const located=await locateDouyinEditor();
+  if(!located.ok)return located;
+  const endpoint=await js(String.raw`(() => {
+    const editor=document.querySelector('#vp2-douyin-editor');if(!editor)return {ok:false,reason:'douyin editor lost'}
+    const walker=document.createTreeWalker(editor,NodeFilter.SHOW_TEXT);let node,last=null;while((node=walker.nextNode())){if(String(node.nodeValue||'').length)last=node}
+    const er=editor.getBoundingClientRect();if(!last)return {ok:true,point:{x:er.left+12,y:er.top+20}}
+    const range=document.createRange();range.setStart(last,Math.max(0,last.nodeValue.length-1));range.setEnd(last,last.nodeValue.length);const rect=range.getBoundingClientRect();
+    return {ok:true,point:{x:Math.min(er.right-6,Math.max(er.left+6,rect.right+2)),y:Math.min(er.bottom-6,Math.max(er.top+6,rect.top+rect.height/2))}}
+  })()`);
+  if(!endpoint.ok)return endpoint;
+  try{await click([endpoint.point.x,endpoint.point.y],{label:'focus douyin body end'})}catch(error){return {ok:false,reason:String(error?.message||error)}}
+  await wait(.2);
+  return {ok:true,point:endpoint.point};
+}
+
+async function clearAndFillDouyinBody() {
+  let located=await locateDouyinEditor();if(!located.ok)return located;
   for(let attempt=0;attempt<3;attempt+=1){
-    const selected=await focus(false);if(!selected.ok)continue;await wait(.2);await pressKey('Backspace').catch(()=>{});await wait(.7);
-    if(!String((await locate()).text||'').replace(/[\s\u200b]/g,''))break;
+    try{await click([located.point.x,located.point.y],{label:'focus douyin body'})}catch(error){return {ok:false,reason:String(error?.message||error)}}
+    await cdp('Input.dispatchKeyEvent',{type:'keyDown',modifiers:4,key:'a',code:'KeyA',windowsVirtualKeyCode:65});
+    await cdp('Input.dispatchKeyEvent',{type:'keyUp',modifiers:4,key:'a',code:'KeyA',windowsVirtualKeyCode:65});
+    await pressKey('Backspace').catch(()=>{});await wait(.7);
+    located=await locateDouyinEditor();if(!String(located.text||'').replace(/[\s\u200b]/g,''))break;
   }
-  const cleared=await locate();if(String(cleared.text||'').replace(/[\s\u200b]/g,''))return {ok:false,reason:'douyin description editor did not clear',text:cleared.text};
-  if(douyinDescription){const focused=await focus(true);if(!focused.ok)return focused;await cdp('Input.insertText',{text:douyinDescription});await wait(1);}
-  const after=await locate();const ok=String(after.text||'').replace(/[\s\u200b]/g,'')===String(douyinDescription||'').replace(/[\s\u200b]/g,'');return ok?{ok:true,text:after.text}:{ok:false,reason:'douyin description did not persist exact value',expected:douyinDescription,actual:after.text};
+  const cleared=await locateDouyinEditor();if(String(cleared.text||'').replace(/[\s\u200b]/g,''))return {ok:false,reason:'douyin description editor did not clear',text:cleared.text};
+  if(douyinDescription){const focused=await focusDouyinEditorEnd();if(!focused.ok)return focused;await cdp('Input.insertText',{text:douyinDescription});await wait(1);}
+  const after=await locateDouyinEditor();const ok=String(after.text||'').replace(/[\s\u200b]/g,'')===String(douyinDescription||'').replace(/[\s\u200b]/g,'');return ok?{ok:true,text:after.text}:{ok:false,reason:'douyin description did not persist exact value',expected:douyinDescription,actual:after.text};
 }
 
 async function addDouyinTopic(tag) {
-  const focused=await js(String.raw`(() => {const c=v=>String(v||'').replace(/\s+/g,' ').trim();const visible=el=>{const r=el.getBoundingClientRect(),s=getComputedStyle(el);return r.width>180&&r.height>50&&s.display!=='none'&&s.visibility!=='hidden'};const editor=[...document.querySelectorAll('[contenteditable="true"],[contenteditable=""]')].map(el=>{const r=el.getBoundingClientRect();let p=el.parentElement,context='';for(let i=0;p&&i<5;i+=1){context+=' '+c(p.innerText||p.textContent||'');p=p.parentElement}return {el,r,context,cls:String(el.className||'')}}).filter(item=>visible(item.el)&&!item.el.closest('[role="dialog"],[class*="modal"],[class*="dialog"]')).sort((a,b)=>Number(/作品描述|#添加话题|@好友/.test(b.context))-Number(/作品描述|#添加话题|@好友/.test(a.context))||Number(/editor|zone|ace/.test(b.cls))-Number(/editor|zone|ace/.test(a.cls))||b.r.width*b.r.height-a.r.width*a.r.height)[0];if(!editor)return {ok:false,reason:'douyin description editor missing'};editor.el.scrollIntoView({block:'center',inline:'center'});editor.el.focus();const selection=window.getSelection(),range=document.createRange();range.selectNodeContents(editor.el);range.collapse(false);selection.removeAllRanges();selection.addRange(range);const r=editor.el.getBoundingClientRect();return {ok:true,point:{x:r.right-18,y:r.top+20}}})()`);
-  if(!focused.ok)return focused;await click([focused.point.x,focused.point.y],{label:'focus douyin body end'}).catch(()=>{});await wait(.2);
-  await js(String.raw`(() => {const editor=[...document.querySelectorAll('[contenteditable="true"],[contenteditable=""]')].find(el=>/zone-container|editor-kit/.test(String(el.className||'')));if(!editor)return false;editor.focus();const selection=window.getSelection(),range=document.createRange();range.selectNodeContents(editor);range.collapse(false);selection.removeAllRanges();selection.addRange(range);return true})()`);
+  const focused=await focusDouyinEditorEnd();
+  if(!focused.ok)return focused;
+  await cdp('Input.insertText',{text:' '});await wait(.2);
   const buttonPoint=await js(String.raw`(() => {const c=v=>String(v||'').replace(/\s+/g,' ').trim();const item=[...document.querySelectorAll('button,[role="button"],div,span')].map(el=>({el,text:c(el.innerText||el.textContent||''),r:el.getBoundingClientRect()})).filter(x=>x.text==='#添加话题'&&x.r.width>20&&x.r.width<140&&x.r.height>=8&&x.r.height<50).sort((a,b)=>a.r.width*a.r.height-b.r.width*b.r.height)[0];if(!item)return null;item.el.scrollIntoView({block:'center',inline:'center'});const r=item.el.getBoundingClientRect();return {x:r.left+r.width/2,y:r.top+r.height/2}})()`);
   if(!buttonPoint)return {ok:false,reason:'douyin add-topic button missing'};await click([buttonPoint.x,buttonPoint.y],{label:`open douyin topic ${tag}`}).catch(()=>{});await wait(.7);await cdp('Input.insertText',{text:String(tag).trim()});await wait(2.4);
   const findRow=()=>js(String.raw`((tag) => {const c=v=>String(v||'').replace(/\s+/g,' ').trim();const expected='#'+String(tag).toLowerCase();const containers=[...document.querySelectorAll('[class*="mention-suggest-item-container"],.mention-suggest-mount-dom')].filter(el=>{const r=el.getBoundingClientRect(),s=getComputedStyle(el);return r.width>0&&r.height>0&&s.display!=='none'&&s.visibility!=='hidden'});const rows=containers.flatMap(container=>[...container.querySelectorAll('*')]).map(el=>({text:c(el.innerText||el.textContent||''),r:el.getBoundingClientRect()})).filter(item=>item.r.height>20&&item.r.height<90&&item.r.width>150&&(item.text.toLowerCase()===expected||item.text.toLowerCase().startsWith(expected+' '))).sort((a,b)=>a.text.length-b.text.length);const item=rows[0];return item?{x:item.r.left+Math.min(56,item.r.width/3),y:item.r.top+item.r.height/2,text:item.text}:null})(${JSON.stringify(tag)})`);
@@ -153,7 +197,8 @@ async function addDouyinTopic(tag) {
   if(!row)return {ok:false,reason:'exact douyin topic suggestion missing',tag};await click([row.x,row.y],{label:`commit douyin topic ${tag}`}).catch(()=>{});await wait(1.4);
   let state=await inspectDouyin();let committed=(state.gates.tags.evidence?.selected||[]).some(value=>String(value).toLowerCase()===String(tag).toLowerCase());
   if(!committed){const retry=await findRow();if(retry){await click([retry.x,retry.y],{label:`retry douyin topic ${tag}`}).catch(()=>{});await wait(1.2);state=await inspectDouyin();committed=(state.gates.tags.evidence?.selected||[]).some(value=>String(value).toLowerCase()===String(tag).toLowerCase())}}
-  return committed?{ok:true,text:row.text}:{ok:false,reason:'douyin topic entity was not committed',tag,evidence:state.gates.tags.evidence};
+  if(committed){await pressKey('ArrowRight').catch(()=>{});await cdp('Input.insertText',{text:' '}).catch(()=>{});await wait(.3);return {ok:true,text:row.text}}
+  return {ok:false,reason:'douyin topic entity was not committed',tag,evidence:state.gates.tags.evidence};
 }
 
 async function turnOffDouyinSync() {
@@ -221,8 +266,10 @@ async function mutateDouyin() {
       const beforeUrls = before.gates.cover.evidence?.urls || {};
       const existingDistinct = (beforeUrls.portrait || []).some(url => url && (beforeUrls.landscape || []).some(other => other && other !== url));
       if (existingDistinct && !expectedReceipts.cover) {
+        const current = await inspectDouyin();
         return {
-          ...before,
+          ...current,
+          actions,
           blocker: typedBlocker('STATE_AMBIGUOUS', '抖音页面已有双封面，但正式回执和崩溃恢复 checkpoint 均缺失，无法证明素材身份；拒绝盲目重传', { retryable: false, evidence: { urls: beforeUrls } }),
         };
       }


### PR DESCRIPTION
## Summary
- retry explicit Douyin upload failures once without waiting the full timeout
- make Douyin rich-description clearing and topic insertion deterministic
- add a narrowly scoped Bilibili cover-completion fallback
- align originality intake docs with the persisted onboarding policy

## Verification
- 22/22 automated tests pass
- skill structure validation passes
- four-platform real draft verification returns READY from the public repository copy
- checkpoint-loss recovery returns READY with no duplicate upload or UI mutation
- no final publish control was clicked