### PR TITLE
Harden Douyin content evidence

### DIFF
--- a/video-publisher/SKILL.md
+++ b/video-publisher/SKILL.md
@@ -180,6 +180,8 @@ The onboarded `all_videos_original` policy also passed real mutation without `--
 
 A second cold-start regression used a different 308 MB source video and four fresh task spaces. Bilibili quarantined a real foreign draft before upload. Douyin recovered from a visible upload failure with bounded reinjection, then rebuilt a corrupted rich description into the exact body plus five topic entities. Bilibili closed a framework-swallowed cover dialog through its exact scoped completion control. Both platforms wrote fingerprint-bound cover checkpoints. After the main-state receipts were deliberately removed, the next full run restored them from those checkpoints and all four platforms returned `READY` without upload or mutation. Three additional consecutive full reruns were also no-op `READY` passes. No final publish control was clicked.
 
+A third cold-start regression used another 208 MB source, a longer Chinese title, prose that repeated two requested topic words, a platform activity entity without a literal `#`, and different cover assets. It exposed and repaired native-title character loss, false plain-topic residue, and a delayed Douyin landscape-card URL. The repaired job reached four-platform `READY`, passed three consecutive no-op full reruns, then restored a deliberately removed Douyin state receipt from its fingerprint-bound checkpoint without mutation. No final publish control was clicked.
+
 A passing platform-specific diagnostic still does not replace this system-level regression when scheduler, persistence, or shared-browser behavior changes.
 
 Real creator-page evidence is the acceptance gate for adapter changes. Unit tests validate orchestration and parsing, not live selectors.

--- a/video-publisher/references/platform-douyin.md
+++ b/video-publisher/references/platform-douyin.md
@@ -14,6 +14,8 @@ Treat a visible `上传失败，重新上传` state as terminal evidence for the
 
 Clear the rich description editor with a real click inside the editor followed by real `Meta+A` and Backspace, then verify it is empty before rebuilding content. Direct value replacement or DOM-only selection can leave duplicated framework state.
 
+For the native title input, use real focus, the input element's verified full-range selection, real Backspace, and one CDP `Input.insertText` call. Do not type a Chinese title character by character, and do not append unless the field has been freshly proven empty. Retry the bounded clear-and-insert sequence only when the exact value does not persist.
+
 ## Topic Entities
 
 For each topic:
@@ -25,6 +27,8 @@ For each topic:
 5. Press real ArrowRight to leave the committed entity, insert one separator space, and verify the entity before continuing.
 
 Accept the platform’s official activity entity form and exact selected `#话题` form. Reject plain hashtag residue and duplicates.
+
+The description may truthfully contain a requested topic word such as `HTML` or `Vercel`. To detect plain topic residue, first remove committed entity nodes and the exact expected description prefix, then inspect only the remaining tail. Do not reject a correct description merely because its prose contains a topic word. An activity entity may render without a literal `#`; `data-mention="activity"` plus the exact visible entity label is valid page evidence.
 
 ## Account Setting
 
@@ -43,7 +47,7 @@ Use the platform’s portrait upload, then `设置横封面`, then complete the 
 
 The main portrait and landscape cards must expose two distinct accepted URLs. A temporary mirrored URL in both cards is not success. Persist both receipts and require verify to match them.
 
-The landscape card may update after the completion control closes. Wait until both cards are non-empty and distinct before building receipts. A known older receipt may be repaired only when it proves both real slot uploads, the portrait receipt still matches the live portrait card, both asset paths/ratios are exact, and the delayed live landscape card is distinct; otherwise re-upload or block.
+The landscape card may update after the completion control closes. Wait until both cards are non-empty and distinct before building receipts. A known older receipt may be repaired only when it proves both real slot uploads, both asset paths/ratios are exact, and fresh page truth exposes distinct live slots. Accept either a previously mirrored two-slot capture whose portrait still matches, or a stale landscape capture where the recorded `afterUrl` was also its `beforeUrl` and the live landscape has advanced beyond that set. Otherwise re-upload or block.
 
 Persist the completed two-slot receipt through the shared atomic checkpoint before returning the mutation result. If both live slots are already distinct but no matching receipt/checkpoint exists, block instead of treating URL distinctness as proof of local-asset identity.
 
@@ -62,4 +66,4 @@ visible enabled 发布 button
 final publish not clicked
 ```
 
-This path passed a fresh 308 MB real draft run on 2026-07-14, including recovery from an explicit upload failure, exact reconstruction of a previously corrupted rich description, and repeated no-op verification.
+This path passed fresh 308 MB and 208 MB real draft runs on 2026-07-14, including recovery from an explicit upload failure, exact reconstruction of a previously corrupted rich description, a long Chinese title that initially lost a character, topic words repeated in prose, delayed landscape-cover receipt repair, checkpoint recovery, and repeated no-op verification.

--- a/video-publisher/scripts/v2/platforms/douyin.mjs
+++ b/video-publisher/scripts/v2/platforms/douyin.mjs
@@ -37,7 +37,9 @@ async function inspectDouyin() {
     let proseRaw=String(clone?.innerText||clone?.textContent||'').replace(/\u200b/g,' ')
     for(const tag of requestedTopics)proseRaw=proseRaw.replace(new RegExp('(?:^|\\s)#'+escapeRegExp(tag)+'(?=$|\\s)','gi'),' ')
     const prose = compact(proseRaw)
-    const plainResidue = requestedTopics.filter(tag=>new RegExp('(?:^|\\s)'+escapeRegExp(tag)+'(?=$|\\s)','i').test(prose))
+    const expectedProse = compact(expectedDescription)
+    const residueTail = expectedProse && prose.startsWith(expectedProse) ? prose.slice(expectedProse.length).trim() : prose
+    const plainResidue = requestedTopics.filter(tag=>new RegExp('(?:^|\\s)'+escapeRegExp(tag)+'(?=$|\\s)','i').test(residueTail))
     const uploadSucceeded = /上传成功|重新上传/.test(text) && /作品描述|基础信息/.test(text)
     const uploading = /上传过程中|取消上传|上传剩余时间|已上传：|上传速度|当前速度/.test(text) && !/上传成功/.test(text)
     const uploadFailed = /上传失败|网络错误|重新上传失败/.test(text)
@@ -142,10 +144,23 @@ async function setDouyinTitle() {
   const selector='input[placeholder*="作品标题"]';
   const before=await js(String.raw`((selector) => {const el=document.querySelector(selector);if(!el)return null;el.scrollIntoView({block:'center',inline:'center'});return el.value})(${JSON.stringify(selector)})`);
   if(before===null)return {ok:false,reason:'douyin title input missing'};
-  try{await fillInput(selector,douyinTitle)}catch(error){return {ok:false,reason:String(error?.message||error)}}
-  await js(String.raw`((selector) => {document.querySelector(selector)?.blur();return true})(${JSON.stringify(selector)})`);await wait(1);
-  const after=await js(String.raw`((selector) => document.querySelector(selector)?.value||'')(${JSON.stringify(selector)})`);
-  return after===douyinTitle?{ok:true,before,value:after}:{ok:false,reason:'douyin title input did not persist exact value',expected:douyinTitle,actual:after};
+  let after=before;
+  for(let attempt=1;attempt<=3&&after!==douyinTitle;attempt+=1){
+    const exposed=await js(String.raw`((selector) => {const el=document.querySelector(selector);if(!el)return {ok:false};el.id='vp2-douyin-title';el.scrollIntoView({block:'center',inline:'center'});return {ok:true,selector:'#vp2-douyin-title'}})(${JSON.stringify(selector)})`);
+    if(!exposed.ok)return {ok:false,reason:'douyin title input missing during retry'};
+    try{await click(exposed.selector,{label:'focus douyin title'})}catch(error){return {ok:false,reason:String(error?.message||error)}}
+    const selected=await js(String.raw`((selector) => {const el=document.querySelector(selector);if(!el)return {ok:false};el.focus();el.select();return {ok:el.selectionStart===0&&el.selectionEnd===el.value.length,start:el.selectionStart,end:el.selectionEnd,length:el.value.length}})(${JSON.stringify(selector)})`);
+    if(!selected.ok)continue;
+    await pressKey('Backspace').catch(()=>{});
+    await wait(.25);
+    const cleared=await js(String.raw`((selector) => (document.querySelector(selector)?.value||'')==='')(${JSON.stringify(selector)})`);
+    if(!cleared)continue;
+    await cdp('Input.insertText',{text:douyinTitle});
+    await wait(.5);
+    await js(String.raw`((selector) => {document.querySelector(selector)?.blur();return true})(${JSON.stringify(selector)})`);await wait(.7);
+    after=await js(String.raw`((selector) => document.querySelector(selector)?.value||'')(${JSON.stringify(selector)})`);
+  }
+  return after===douyinTitle?{ok:true,before,value:after}:{ok:false,reason:'douyin title input did not persist exact value after bounded retries',expected:douyinTitle,actual:after};
 }
 
 async function locateDouyinEditor() {
@@ -227,11 +242,20 @@ async function repairDelayedDouyinCoverReceipt(){
   if(!prior?.slots?.portrait||!prior?.slots?.landscape)return {ok:false,skipped:true};
   const expected=Object.fromEntries(douyinCoverAssets.map(asset=>[asset.slot,asset]));
   if(!['portrait','landscape'].every(slot=>prior.slots[slot].assetPath===expected[slot].path&&prior.slots[slot].ratio===expected[slot].ratio))return {ok:false,skipped:true};
-  if(prior.slots.portrait.afterUrl!==prior.slots.landscape.afterUrl)return {ok:false,skipped:true};
   const state=await inspectDouyin();const urls=state.gates.cover.evidence?.urls||{};
-  const portrait=(urls.portrait||[]).find(Boolean);const landscape=(urls.landscape||[]).find(url=>url&&url!==portrait);
-  if(!portrait||!landscape||!(urls.portrait||[]).includes(prior.slots.portrait.afterUrl))return {ok:false,skipped:true};
-  const receipt={slots:{portrait:{...prior.slots.portrait,afterUrl:portrait},landscape:{...prior.slots.landscape,afterUrl:landscape}}};
+  const live={
+    portrait:(urls.portrait||[]).find(url=>url&&!(urls.landscape||[]).includes(url)),
+    landscape:(urls.landscape||[]).find(url=>url&&!(urls.portrait||[]).includes(url)),
+  };
+  if(!live.portrait||!live.landscape)return {ok:false,skipped:true};
+  const mirroredCapture=prior.slots.portrait.afterUrl===prior.slots.landscape.afterUrl&&(urls.portrait||[]).includes(prior.slots.portrait.afterUrl);
+  for(const slot of ['portrait','landscape']){
+    const item=prior.slots[slot];
+    if(live[slot]===item.afterUrl)continue;
+    const capturedStale=(item.beforeUrls||[]).includes(item.afterUrl)&&!(item.beforeUrls||[]).includes(live[slot]);
+    if(!(capturedStale||(slot==='landscape'&&mirroredCapture)))return {ok:false,skipped:true};
+  }
+  const receipt={slots:{portrait:{...prior.slots.portrait,afterUrl:live.portrait},landscape:{...prior.slots.landscape,afterUrl:live.landscape}}};
   return {ok:true,receipt,reason:'repaired delayed landscape card after both real slot uploads'};
 }
 


### PR DESCRIPTION
## Summary
- set native Douyin titles with verified clear-before-insert semantics
- distinguish requested topic words in legitimate prose from plain topic residue
- repair delayed landscape-cover receipts only from action-bound evidence
- document the third real four-platform cold-start regression

## Verification
- 22/22 automated tests pass
- skill validation passes
- a fresh 208 MB four-platform cold start reached READY after repairing the discovered edge cases
- three consecutive reruns were no-op READY passes
- receipt-loss recovery restored from the fingerprint-bound checkpoint without mutation
- the public repository copy returned READY on all four platforms
- no final publish control was clicked