### PR TITLE
Recover corrupt publisher job state

### DIFF
--- a/video-publisher/SKILL.md
+++ b/video-publisher/SKILL.md
@@ -63,6 +63,8 @@ Custom-cover dialogs also use the single UI queue. Isolated task spaces do not m
 
 Accepted cover receipts are written to atomic, fingerprint-bound checkpoints inside the job directory before an adapter returns. This closes the crash window between a successful creator-page mutation and the orchestrator recording its result. A resumed run still has to match the checkpoint against fresh page truth.
 
+Job state also keeps a one-generation atomic backup. If `state.json` is invalid JSON, restore only a backup whose package fingerprint matches, preserve the corrupt primary as `state.corrupt-<timestamp>.json`, and then re-inspect every platform. Never turn restored state into `READY` without fresh page verification.
+
 ## Browser Rules
 
 - Use `ego-browser`; do not fall back to Chrome control.
@@ -197,6 +199,8 @@ A ninth cold-start regression used a 1.12 GB, 15:09 HEVC source with custom-cove
 A tenth boundary regression stream-copied exactly 15:00 from that source. ISO BMFF reported 900.010 seconds because of final-packet rounding; the 1.113 GB HEVC file uploaded to Douyin on its first diagnostic attempt and passed exact title, description, five topic entities, settings, platform-default cover, final-button, and safety verification. After adding the 0.1-second tolerance, the production orchestrator repeated the upload in a fresh task space, reached `READY`, and passed three no-op reruns. The preflight therefore allows only 0.1 seconds above 900 for container rounding while still rejecting materially longer content. Every final guard remained armed with zero attempts.
 
 An eleventh four-platform regression used a fresh 94 MB H.264 source and platform-default covers, then terminated the orchestrator during serialized Douyin topic insertion after every upload had completed and Xiaohongshu had reached `READY`. Fresh recovery evidence found the exact Douyin title and body plus exactly two of five committed topics; it reported only `tags` missing. The same job reused all four task-space ids, performed no video upload, rebuilt the Douyin rich editor without duplication, completed Bilibili and WeChat Channels serially, and reached four-platform `READY`. Three additional full reruns were no-op `READY` passes. Every final guard remained armed with zero attempts, and no final publish control was clicked.
+
+A twelfth cold-start regression used a real 45 MB, 27-second, 120fps MOV with two whitespace-bearing topic names and platform-default covers. All four platforms accepted the MOV and reached `READY`; three full reruns were no-op passes. Deliberately corrupting the completed job's `state.json` first reproduced a fatal JSON parse. After adding atomic state backups, a second corruption was preserved as a timestamped artifact, the matching backup restored all four numeric task-space ids, and fresh inspection/verification returned four-platform `READY` with no upload or UI mutation. A further no-op rerun remained `READY`; all final guards stayed armed with zero attempts.
 
 A passing platform-specific diagnostic still does not replace this system-level regression when scheduler, persistence, or shared-browser behavior changes.
 

--- a/video-publisher/references/platform-common.md
+++ b/video-publisher/references/platform-common.md
@@ -113,6 +113,8 @@ A mutation result is not enough. The final `verify` phase must re-read the page 
 
 The production runner also writes accepted cover receipts to an atomic per-job, per-platform checkpoint. On restart, the orchestrator loads only checkpoints whose platform and package fingerprint match the current job, then performs the same fresh page verification. Checkpoints are recovery evidence, not a substitute for `verify`.
 
+Every completed state save keeps the prior valid `state.json` as an atomic one-generation backup. If the primary file is invalid JSON, restore only when the backup fingerprint matches the current package, preserve the corrupt primary with a timestamped filename, and re-run normal inspect/verify. If the backup is missing, invalid, or belongs to another fingerprint, fail closed before browser work.
+
 ## Cover Receipts
 
 When custom covers are enabled, persist a receipt containing:

--- a/video-publisher/references/scripts.md
+++ b/video-publisher/references/scripts.md
@@ -68,7 +68,7 @@ Options:
 
 UI concurrency is fixed at `1` and has no public override.
 
-State defaults to `~/.video-publisher/v2-jobs/<job-id>/`. The job stores the package fingerprint, numeric task-space ids, receipts, observations, compact verdicts, and atomic receipt checkpoints under `checkpoints/`.
+State defaults to `~/.video-publisher/v2-jobs/<job-id>/`. The job stores the package fingerprint, numeric task-space ids, receipts, observations, compact verdicts, an atomic one-generation `state.backup.json`, and receipt checkpoints under `checkpoints/`. An invalid primary state may recover only from a fingerprint-matching backup; the corrupt file is preserved as `state.corrupt-<timestamp>.json`, after which all platform gates are read again.
 
 To resume an interrupted run, repeat the same command with the same `--job-id`. The package fingerprint must match. The orchestrator reuses persisted numeric task-space ids and receipts, restores only fingerprint-matching receipt checkpoints, then inspects page truth again before acting. If Ego explicitly proves a recorded id no longer exists after a browser crash, the runner recreates the same named platform space and writes its new id back; ownership or user-control errors never use this fallback.
 

--- a/video-publisher/scripts/v2/lib/job-store.mjs
+++ b/video-publisher/scripts/v2/lib/job-store.mjs
@@ -1,21 +1,60 @@
 import fs from "node:fs";
 import path from "node:path";
 
+function validState(value) {
+  return value && typeof value === "object" && !Array.isArray(value);
+}
+
+async function readState(filePath) {
+  const parsed = JSON.parse(await fs.promises.readFile(filePath, "utf8"));
+  if (!validState(parsed)) throw new Error(`Job state is not a JSON object: ${filePath}`);
+  return parsed;
+}
+
 export class JobStore {
   constructor(jobDir, initialState) {
     this.jobDir = jobDir;
     this.statePath = path.join(jobDir, "state.json");
+    this.backupPath = path.join(jobDir, "state.backup.json");
     this.evidenceDir = path.join(jobDir, "evidence");
     this.checkpointDir = path.join(jobDir, "checkpoints");
     this.state = initialState;
     this.sequence = 0;
     this.queue = Promise.resolve();
+    this.lastRecovery = null;
   }
 
   async initialize() {
     await fs.promises.mkdir(this.evidenceDir, { recursive: true });
     await fs.promises.mkdir(this.checkpointDir, { recursive: true });
-    if (fs.existsSync(this.statePath)) this.state = JSON.parse(await fs.promises.readFile(this.statePath, "utf8"));
+    const expectedFingerprint = this.state?.fingerprint || null;
+    if (fs.existsSync(this.statePath)) {
+      try {
+        this.state = await readState(this.statePath);
+      } catch (primaryError) {
+        let backup;
+        try {
+          backup = await readState(this.backupPath);
+        } catch (backupError) {
+          throw new Error(
+            `Job state is corrupted and no valid atomic backup is available: ${this.statePath}; `
+            + `primary=${String(primaryError?.message || primaryError)}; backup=${String(backupError?.message || backupError)}`,
+          );
+        }
+        if (expectedFingerprint && backup.fingerprint !== expectedFingerprint) {
+          throw new Error(`Job state backup belongs to another package: ${this.backupPath}`);
+        }
+        const recoveredAt = new Date().toISOString();
+        const stamp = recoveredAt.replace(/[:.]/g, "-");
+        const corruptPath = path.join(this.jobDir, `state.corrupt-${stamp}.json`);
+        await fs.promises.rename(this.statePath, corruptPath);
+        this.state = backup;
+        this.state.recoveryEvents ||= [];
+        this.state.recoveryEvents.push({ recoveredAt, backupPath: this.backupPath, corruptPath });
+        if (this.state.recoveryEvents.length > 20) this.state.recoveryEvents = this.state.recoveryEvents.slice(-20);
+        this.lastRecovery = { recoveredAt, backupPath: this.backupPath, corruptPath };
+      }
+    }
     await this.save();
     return this.state;
   }
@@ -40,9 +79,22 @@ export class JobStore {
     this.state.updatedAt = new Date().toISOString();
     const body = JSON.stringify(this.state, null, 2) + "\n";
     const temp = `${this.statePath}.${process.pid}.${++this.sequence}.tmp`;
+    const backupTemp = `${this.backupPath}.${process.pid}.${this.sequence}.tmp`;
     this.queue = this.queue.then(async () => {
-      await fs.promises.writeFile(temp, body);
-      await fs.promises.rename(temp, this.statePath);
+      try {
+        await fs.promises.writeFile(temp, body);
+        if (fs.existsSync(this.statePath)) {
+          await fs.promises.copyFile(this.statePath, backupTemp);
+          await fs.promises.rename(backupTemp, this.backupPath);
+        }
+        await fs.promises.rename(temp, this.statePath);
+      } catch (error) {
+        await Promise.allSettled([
+          fs.promises.rm(temp, { force: true }),
+          fs.promises.rm(backupTemp, { force: true }),
+        ]);
+        throw error;
+      }
     });
     return this.queue;
   }

--- a/video-publisher/scripts/v2/publisher.mjs
+++ b/video-publisher/scripts/v2/publisher.mjs
@@ -125,6 +125,9 @@ async function main() {
   const jobDir = path.join(args.stateRoot, jobId);
   const store = new JobStore(jobDir, initialState(jobId, identity, args));
   const state = await store.initialize();
+  if (store.lastRecovery) {
+    console.error(`[video-publisher-v2] restored corrupt job state from atomic backup; preserved=${store.lastRecovery.corruptPath}`);
+  }
   if (state.fingerprint !== identity.fingerprint) throw new Error(`Job ${jobId} belongs to another package`);
   for (const platform of args.platforms) state.platforms[platform] ||= { status: "new", taskSpaceId: null, receipts: {}, verdict: null, history: [] };
   for (const platform of args.platforms) {

--- a/video-publisher/scripts/v2/tests/job-store.test.mjs
+++ b/video-publisher/scripts/v2/tests/job-store.test.mjs
@@ -21,3 +21,55 @@ test("job store restores only matching receipt checkpoints", async () => {
   assert.equal(await store.loadReceiptCheckpoint("douyin", "another-package"), null);
   assert.equal(await store.loadReceiptCheckpoint("bilibili", "matching-fingerprint"), null);
 });
+
+test("job store restores a corrupt primary from its atomic backup", async () => {
+  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "video-publisher-state-recovery-test-"));
+  const initial = {
+    schemaVersion: 3,
+    fingerprint: "state-recovery-fingerprint",
+    status: "new",
+    platforms: { douyin: { taskSpaceId: null } },
+  };
+  const store = new JobStore(root, structuredClone(initial));
+  const state = await store.initialize();
+  state.platforms.douyin.taskSpaceId = 42;
+  await store.save();
+  state.status = "ready";
+  await store.save();
+  await store.close();
+
+  await fs.promises.writeFile(store.statePath, "{BROKEN_STATE");
+  const recoveredStore = new JobStore(root, structuredClone(initial));
+  const recovered = await recoveredStore.initialize();
+  await recoveredStore.close();
+
+  assert.equal(recovered.platforms.douyin.taskSpaceId, 42);
+  assert.equal(recovered.status, "new", "the backup is deliberately one completed save behind");
+  assert.equal(recovered.recoveryEvents.length, 1);
+  assert.equal(recoveredStore.lastRecovery.backupPath, recoveredStore.backupPath);
+  assert.equal(fs.existsSync(recoveredStore.lastRecovery.corruptPath), true);
+  assert.equal(await fs.promises.readFile(recoveredStore.lastRecovery.corruptPath, "utf8"), "{BROKEN_STATE");
+  assert.doesNotThrow(() => JSON.parse(fs.readFileSync(recoveredStore.statePath, "utf8")));
+  assert.equal(JSON.parse(await fs.promises.readFile(recoveredStore.backupPath, "utf8")).platforms.douyin.taskSpaceId, 42);
+});
+
+test("job store refuses a corrupt primary when no valid backup exists", async () => {
+  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "video-publisher-state-no-backup-test-"));
+  await fs.promises.mkdir(root, { recursive: true });
+  await fs.promises.writeFile(path.join(root, "state.json"), "{BROKEN_STATE");
+  const store = new JobStore(root, { schemaVersion: 3, fingerprint: "expected", platforms: {} });
+  await assert.rejects(store.initialize(), /no valid atomic backup/);
+});
+
+test("job store never restores a backup from another package fingerprint", async () => {
+  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "video-publisher-state-wrong-backup-test-"));
+  await fs.promises.writeFile(path.join(root, "state.json"), "{BROKEN_STATE");
+  await fs.promises.writeFile(path.join(root, "state.backup.json"), JSON.stringify({
+    schemaVersion: 3,
+    fingerprint: "another-package",
+    platforms: {},
+  }));
+  const store = new JobStore(root, { schemaVersion: 3, fingerprint: "expected-package", platforms: {} });
+  await assert.rejects(store.initialize(), /backup belongs to another package/);
+  assert.equal(await fs.promises.readFile(path.join(root, "state.json"), "utf8"), "{BROKEN_STATE");
+});


### PR DESCRIPTION
## Summary
- keep an atomic one-generation backup for publisher job state
- recover invalid JSON only from a fingerprint-matching backup and preserve the corrupt primary
- re-run normal page inspection and verification after recovery instead of trusting stored READY
- document the real MOV and state-corruption regression

## Verification
- real 45 MB / 27s / 120fps MOV reached four-platform READY with default covers and two whitespace-bearing topics
- three full reruns were no-op READY
- first state corruption reproduced the prior fatal JSON parse
- after the fix, a second corruption restored task spaces 68/70/69/71, preserved the corrupt artifact, and reached four-platform READY with no upload or UI mutation
- a further rerun remained no-op READY
- 29/29 tests pass, including missing/invalid/wrong-fingerprint backup cases
- both quick_validate checks pass and privacy scan is clean
- all final guards stayed armed with zero attempts