### PR TITLE
Serialize publisher orchestrators per job

### DIFF
--- a/video-publisher/SKILL.md
+++ b/video-publisher/SKILL.md
@@ -48,6 +48,8 @@ This invokes `scripts/v2/publisher.mjs`. The older Agent-per-platform implementa
 
 Use one orchestrator and one Ego Lite task space per platform. Do not delegate live browser control to sub Agents. Agents may help prepare copy or inspect saved artifacts, but they must not control creator tabs.
 
+The publisher enforces one orchestrator per job with an atomic job-directory lock before any state write or browser phase. A duplicate invocation must fail immediately while the owner continues; a lock whose recorded PID is dead is stale and may be removed automatically. Keep the separate platform locks as defense in depth across different jobs.
+
 Schedule by resource type:
 
 ```text
@@ -201,6 +203,8 @@ A tenth boundary regression stream-copied exactly 15:00 from that source. ISO BM
 An eleventh four-platform regression used a fresh 94 MB H.264 source and platform-default covers, then terminated the orchestrator during serialized Douyin topic insertion after every upload had completed and Xiaohongshu had reached `READY`. Fresh recovery evidence found the exact Douyin title and body plus exactly two of five committed topics; it reported only `tags` missing. The same job reused all four task-space ids, performed no video upload, rebuilt the Douyin rich editor without duplication, completed Bilibili and WeChat Channels serially, and reached four-platform `READY`. Three additional full reruns were no-op `READY` passes. Every final guard remained armed with zero attempts, and no final publish control was clicked.
 
 A twelfth cold-start regression used a real 45 MB, 27-second, 120fps MOV with two whitespace-bearing topic names and platform-default covers. All four platforms accepted the MOV and reached `READY`; three full reruns were no-op passes. Deliberately corrupting the completed job's `state.json` first reproduced a fatal JSON parse. After adding atomic state backups, a second corruption was preserved as a timestamped artifact, the matching backup restored all four numeric task-space ids, and fresh inspection/verification returned four-platform `READY` with no upload or UI mutation. A further no-op rerun remained `READY`; all final guards stayed armed with zero attempts.
+
+A thirteenth regression started two production orchestrators against that same ready four-platform job at the same instant. With only platform locks, each process acquired a different subset, both failed, and the shared job was left `running`. The new job-level atomic lock made the same real double launch deterministic: one invocation was refused before state/browser work while the owner completed four-platform `READY`. A deliberately planted dead-PID job lock was then removed automatically, the job remained no-op `READY`, and the lock was released after completion.
 
 A passing platform-specific diagnostic still does not replace this system-level regression when scheduler, persistence, or shared-browser behavior changes.
 

--- a/video-publisher/references/platform-common.md
+++ b/video-publisher/references/platform-common.md
@@ -6,6 +6,8 @@ Read this file and the exact platform reference before changing a live adapter.
 
 One orchestrator owns all platform task spaces. Do not use sub Agents for live creator-page control.
 
+Acquire the job-directory `orchestrator.lock` before reading or writing job state or starting a platform phase. A second process for the same job must fail immediately instead of splitting platform locks with the first process. Remove the lock on every normal exit; after a crash, remove it only when its recorded PID is no longer alive. A fresh lock whose owner file is still being written remains busy.
+
 Never click a final `发布`, `发布笔记`, `发表`, or `立即投稿` button without explicit authorization in the current run. Every adapter result must leave `finalPublishClicked: false`. The shared core installs a capture-phase click/submit guard; safety passes only when `guardArmed: true` and `blockedAttempts: 0` are observed from the live page.
 
 If Ego reports that the user controls a task space, stop the whole browser job. Do not retry, create a replacement task space, or claim it without explicit user confirmation.
@@ -28,6 +30,8 @@ Do not pipeline UI mutations behind unfinished uploads. Live testing showed that
 Before step 1, validate the exact local media for every selected platform. The shared media preflight checks file existence and reads MP4/M4V/MOV duration from ISO BMFF metadata without an external `ffprobe` dependency. Douyin permits only 0.1 seconds of container rounding above its real-tested 900-second content limit; anything longer must be excluded before browser work and recorded as `PLATFORM_REJECTED_ASSET`. Other valid selected platforms continue through the same run. If no selected platform is eligible, fail before job creation. Never silently trim, transcode, or substitute another source.
 
 The maintained adapter runner also takes an atomic per-platform filesystem lock. A second process targeting the same platform fails before opening Ego instead of overlapping with an active upload, mutation, inspection, or verification. Stale locks from dead processes are removed automatically. This still permits the intended four-platform parallel upload/check phases.
+
+The job lock and platform locks solve different races: the first serializes one persisted job, while the latter prevents two different jobs from controlling the same platform simultaneously.
 
 ## Platform Phases
 

--- a/video-publisher/references/scripts.md
+++ b/video-publisher/references/scripts.md
@@ -70,6 +70,8 @@ UI concurrency is fixed at `1` and has no public override.
 
 State defaults to `~/.video-publisher/v2-jobs/<job-id>/`. The job stores the package fingerprint, numeric task-space ids, receipts, observations, compact verdicts, an atomic one-generation `state.backup.json`, and receipt checkpoints under `checkpoints/`. An invalid primary state may recover only from a fingerprint-matching backup; the corrupt file is preserved as `state.corrupt-<timestamp>.json`, after which all platform gates are read again.
 
+While a production invocation owns the job, `<job-dir>/orchestrator.lock/owner.json` records its PID. A simultaneous invocation of the same job exits before state or browser work. Normal completion removes the lock; a later run removes it only when the recorded owner PID is dead.
+
 To resume an interrupted run, repeat the same command with the same `--job-id`. The package fingerprint must match. The orchestrator reuses persisted numeric task-space ids and receipts, restores only fingerprint-matching receipt checkpoints, then inspects page truth again before acting. If Ego explicitly proves a recorded id no longer exists after a browser crash, the runner recreates the same named platform space and writes its new id back; ownership or user-control errors never use this fallback.
 
 Exit codes:

--- a/video-publisher/scripts/v2/lib/job-lock.mjs
+++ b/video-publisher/scripts/v2/lib/job-lock.mjs
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const INVALID_OWNER_GRACE_MS = 5000;
+
+export class JobBusyError extends Error {
+  constructor(jobId, owner = {}) {
+    const ownerText = owner.pid
+      ? `under PID ${owner.pid}`
+      : "by another orchestrator that is still acquiring its lock";
+    super(`Job ${jobId} is already running ${ownerText}; refusing a second orchestrator`);
+    this.name = "JobBusyError";
+    this.jobId = jobId;
+    this.owner = owner;
+  }
+}
+
+function processAlive(pid) {
+  if (!Number.isInteger(pid) || pid < 1) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function readOwner(lockPath) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(lockPath, "owner.json"), "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function invalidOwnerIsStale(lockPath) {
+  try {
+    return Date.now() - fs.statSync(lockPath).mtimeMs > INVALID_OWNER_GRACE_MS;
+  } catch {
+    return false;
+  }
+}
+
+export function acquireJobLock(jobDir, { jobId, packagePath } = {}) {
+  const lockPath = path.join(jobDir, "orchestrator.lock");
+  fs.mkdirSync(jobDir, { recursive: true });
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      fs.mkdirSync(lockPath);
+      const owner = { pid: process.pid, jobId, packagePath, acquiredAt: new Date().toISOString() };
+      fs.writeFileSync(path.join(lockPath, "owner.json"), JSON.stringify(owner, null, 2));
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        const current = readOwner(lockPath);
+        if (current.pid === process.pid) fs.rmSync(lockPath, { recursive: true, force: true });
+      };
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      const owner = readOwner(lockPath);
+      const ownerPid = Number(owner.pid);
+      if ((Number.isInteger(ownerPid) && !processAlive(ownerPid))
+        || (!Number.isInteger(ownerPid) && invalidOwnerIsStale(lockPath))) {
+        fs.rmSync(lockPath, { recursive: true, force: true });
+        continue;
+      }
+      throw new JobBusyError(jobId || path.basename(jobDir), owner);
+    }
+  }
+  throw new Error(`Could not acquire orchestrator lock for job ${jobId || path.basename(jobDir)}`);
+}

--- a/video-publisher/scripts/v2/publisher.mjs
+++ b/video-publisher/scripts/v2/publisher.mjs
@@ -14,6 +14,7 @@ import {
 import { loadConfig } from "../lib/config.mjs";
 import { inspectMediaFile, validateMediaForPlatform } from "../lib/media.mjs";
 import { buildIdentity } from "./lib/identity.mjs";
+import { acquireJobLock } from "./lib/job-lock.mjs";
 import { JobStore } from "./lib/job-store.mjs";
 import { BLOCKER, PLATFORMS, classifyVerdict, compactVerdict, evaluateObservation } from "./lib/model.mjs";
 import { parseV2Result } from "./lib/result-line.mjs";
@@ -25,6 +26,7 @@ const RIGHTS_PLATFORMS = new Set(["xiaohongshu", "bilibili", "wechat_channels"])
 const validators = { xiaohongshu: validateXiaohongshuPackage, douyin: validateDouyinPackage, bilibili: validateBilibiliPackage, wechat_channels: validateWechatChannelsPackage };
 
 class UsageError extends Error {}
+let releaseActiveJobLock = null;
 
 function positive(raw, name) {
   const value = Number(raw);
@@ -123,6 +125,7 @@ async function main() {
   const identity = await buildIdentity(pkg);
   const jobId = args.jobId || identity.fingerprint.slice(0, 16);
   const jobDir = path.join(args.stateRoot, jobId);
+  releaseActiveJobLock = acquireJobLock(jobDir, { jobId, packagePath: args.packagePath });
   const store = new JobStore(jobDir, initialState(jobId, identity, args));
   const state = await store.initialize();
   if (store.lastRecovery) {
@@ -258,7 +261,9 @@ function summary(state, platforms, statePath) {
   };
 }
 
-main().catch(error => {
-  console.error(`[video-publisher-v2] fatal: ${String(error?.stack || error)}`);
-  process.exitCode = error instanceof UsageError ? 2 : 1;
-});
+main()
+  .catch(error => {
+    console.error(`[video-publisher-v2] fatal: ${String(error?.stack || error)}`);
+    process.exitCode = error instanceof UsageError ? 2 : 1;
+  })
+  .finally(() => releaseActiveJobLock?.());

--- a/video-publisher/scripts/v2/tests/job-lock.test.mjs
+++ b/video-publisher/scripts/v2/tests/job-lock.test.mjs
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { acquireJobLock, JobBusyError } from "../lib/job-lock.mjs";
+
+test("job lock permits exactly one orchestrator and releases idempotently", async () => {
+  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "video-publisher-job-lock-test-"));
+  const release = acquireJobLock(root, { jobId: "same-job", packagePath: "/tmp/package.json" });
+  assert.throws(() => acquireJobLock(root, { jobId: "same-job" }), JobBusyError);
+  release();
+  release();
+  const releaseAgain = acquireJobLock(root, { jobId: "same-job" });
+  releaseAgain();
+});
+
+test("job lock removes a stale dead-owner lock", async () => {
+  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "video-publisher-stale-job-lock-test-"));
+  const lockPath = path.join(root, "orchestrator.lock");
+  await fs.promises.mkdir(lockPath);
+  await fs.promises.writeFile(path.join(lockPath, "owner.json"), JSON.stringify({ pid: 99999999, jobId: "same-job" }));
+  const release = acquireJobLock(root, { jobId: "same-job" });
+  release();
+  assert.equal(fs.existsSync(lockPath), false);
+});
+
+test("job lock treats a fresh incomplete owner as busy instead of deleting a live acquisition", async () => {
+  const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "video-publisher-fresh-job-lock-test-"));
+  await fs.promises.mkdir(path.join(root, "orchestrator.lock"));
+  assert.throws(() => acquireJobLock(root, { jobId: "same-job" }), JobBusyError);
+});

--- a/video-publisher/scripts/v2/tests/publisher.test.mjs
+++ b/video-publisher/scripts/v2/tests/publisher.test.mjs
@@ -141,3 +141,23 @@ test("publisher isolates a Douyin duration blocker and still prepares eligible p
   const events=(await fs.promises.readFile(log,"utf8")).trim().split(/\n/).map(line=>JSON.parse(line));
   assert.deepEqual(new Set(events.map(item=>item.platform)),new Set(["xiaohongshu"]));
 });
+
+test("two publishers for the same job produce one winner and one immediate refusal", async () => {
+  const root=await fs.promises.mkdtemp(path.join(os.tmpdir(),"video-publisher-v2-double-run-test-"));
+  const videoPath=path.join(root,"sample-video.mp4");
+  const packagePath=path.join(root,"package.json");
+  const configPath=path.join(root,"config.json");
+  const log=path.join(root,"events.ndjson");
+  await fs.promises.writeFile(videoPath,"test video fixture");
+  await fs.promises.writeFile(configPath,JSON.stringify({schemaVersion:1,onboarding:{completed:true},sourceDirectory:root,defaultPlatforms:["xiaohongshu"],declarations:{originalityPolicy:"all_videos_original"},execution:{checkConcurrency:1,uploadConcurrency:1}}));
+  await fs.promises.writeFile(packagePath,JSON.stringify({videoPath,title:"Double run",xhsTopics:["Test"],cover:{uploadCustomCover:false}}));
+  const args=[path.join(V2_DIR,"publisher.mjs"),packagePath,"double-run","xiaohongshu","--job-id","shared-job","--state-root",root];
+  const options={env:{...process.env,VIDEO_PUBLISHER_CONFIG:configPath,VIDEO_PUBLISHER_V2_RUNNER:path.join(DIR,"mock-runner.mjs"),VIDEO_PUBLISHER_V2_MOCK_LOG:log}};
+  const results=await Promise.all([run(process.execPath,args,options),run(process.execPath,args,options)]);
+  assert.deepEqual(results.map(item=>item.code).sort(),[0,1]);
+  const winner=results.find(item=>item.code===0);
+  const refused=results.find(item=>item.code===1);
+  assert.equal(JSON.parse(winner.stdout).ready,true);
+  assert.match(refused.stderr,/already running.+refusing a second orchestrator/);
+  assert.equal(fs.existsSync(path.join(root,"shared-job","orchestrator.lock")),false);
+});


### PR DESCRIPTION
## Summary
- add an atomic per-job orchestrator lock before state or browser work
- refuse duplicate invocations while allowing the owner to finish
- remove dead-PID locks automatically while treating fresh incomplete owners as busy
- retain per-platform locks as defense in depth across different jobs

## Verification
- before the fix, two real orchestrators split platform locks, both failed, and left the job running
- after the fix, the same double launch produced one immediate refusal and one four-platform READY owner
- a planted dead-PID lock was removed automatically and the real job stayed no-op READY
- 33/33 tests pass, including a concurrent publisher integration test and lock edge cases
- both quick_validate checks pass; source/public copies match; privacy scan clean
- final publish guards remained armed with zero attempts